### PR TITLE
Config: Fix default plugins path

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,5 +1,5 @@
 pg_chacon_num=12325261
-pg_chacon_dir=plugins/jarvis-chacon
+pg_chacon_dir=plugins_installed/jarvis-chacon
 pg_chacon_config='{ "devices":[
     { "name": "SALON", "address": "1"},
     { "name": "SALLE A MANGER", "address": "2"},


### PR DESCRIPTION
Since jarvis now use plugin path "plugins_installed" instead of "plugins", the default config for plugin dir is not working.